### PR TITLE
Update golangci-lint.yml

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,7 +27,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.54
+          version: v1.57.1
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
This PR bumps The linter to a version that natively supports go 1.22